### PR TITLE
fix decorator space

### DIFF
--- a/blog/views.py
+++ b/blog/views.py
@@ -30,7 +30,7 @@ def article_new(request):
     return render(request, 'blog/article_edit.html', {'form': form})
 
 
-@ login_required
+@login_required
 def article_edit(request, pk):
     article = get_object_or_404(Article, pk=pk)
     if request.method == "POST":


### PR DESCRIPTION
Not sure how this happened, maybe a linter gone wild, but a space ended up between the `@` and the decorator label